### PR TITLE
test(stability): restore green test baseline for dispatcher and integration project

### DIFF
--- a/src/BuildingBlocks/BuildingBlocks.Application/Dispatcher/Dispatcher.cs
+++ b/src/BuildingBlocks/BuildingBlocks.Application/Dispatcher/Dispatcher.cs
@@ -196,7 +196,13 @@ public class Dispatcher : IDispatcher
     private async Task ValidateAsync<T>(T request, CancellationToken cancellationToken)
     {
         var validators = new List<IValidator>();
-        validators.AddRange(_serviceProvider.GetServices<IValidator<T>>());
+
+        var declaredValidatorServiceType = typeof(IEnumerable<>).MakeGenericType(typeof(IValidator<>).MakeGenericType(typeof(T)));
+        var declaredValidators = _serviceProvider.GetService(declaredValidatorServiceType) as System.Collections.IEnumerable;
+        if (declaredValidators != null)
+        {
+            validators.AddRange(declaredValidators.Cast<IValidator>());
+        }
 
         var concreteType = request?.GetType();
         if (concreteType != null)

--- a/tests/CleanArchitecture.UnitTests/Dispatcher/DispatcherTests.cs
+++ b/tests/CleanArchitecture.UnitTests/Dispatcher/DispatcherTests.cs
@@ -43,8 +43,8 @@ public class DispatcherTests
 
         // No validators for query (validation passes)
         _serviceProviderMock
-            .Setup(sp => sp.GetService(typeof(IEnumerable<IValidator<IQuery<string>>>)))
-            .Returns(Enumerable.Empty<IValidator<IQuery<string>>>());
+            .Setup(sp => sp.GetService(typeof(IEnumerable<IValidator<TestQuery>>)))
+            .Returns(Enumerable.Empty<IValidator<TestQuery>>());
 
         var dispatcher = new BuildingBlocks.Application.Dispatcher.Dispatcher(
             _serviceProviderMock.Object,
@@ -76,8 +76,8 @@ public class DispatcherTests
 
         // No validators (validation passes)
         _serviceProviderMock
-            .Setup(sp => sp.GetService(typeof(IEnumerable<IValidator<ICommand<int>>>)))
-            .Returns(Enumerable.Empty<IValidator<ICommand<int>>>());
+            .Setup(sp => sp.GetService(typeof(IEnumerable<IValidator<TestCommand>>)))
+            .Returns(Enumerable.Empty<IValidator<TestCommand>>());
 
         var dispatcher = new BuildingBlocks.Application.Dispatcher.Dispatcher(
             _serviceProviderMock.Object,
@@ -96,19 +96,9 @@ public class DispatcherTests
     {
         // Arrange
         var query = new TestQuery { Value = string.Empty };
-        var validatorMock = new Mock<IValidator<IQuery<string>>>();
-        var validationResult = new ValidationResult(new[]
-        {
-            new ValidationFailure("Value", "Value is required")
-        });
-
-        validatorMock
-            .Setup(v => v.ValidateAsync(It.IsAny<ValidationContext<IQuery<string>>>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(validationResult);
-
         _serviceProviderMock
-            .Setup(sp => sp.GetService(typeof(IEnumerable<IValidator<IQuery<string>>>)))
-            .Returns(new[] { validatorMock.Object });
+            .Setup(sp => sp.GetService(typeof(IEnumerable<IValidator<TestQuery>>)))
+            .Returns(new IValidator<TestQuery>[] { new TestQueryValidator() });
 
         var dispatcher = new BuildingBlocks.Application.Dispatcher.Dispatcher(
             _serviceProviderMock.Object,
@@ -116,9 +106,6 @@ public class DispatcherTests
 
         // Act & Assert
         await Assert.ThrowsAsync<ValidationException>(() => dispatcher.DispatchAsync(query));
-        validatorMock.Verify(
-            v => v.ValidateAsync(It.IsAny<ValidationContext<IQuery<string>>>(), It.IsAny<CancellationToken>()),
-            Times.Once);
     }
 
     [Fact]
@@ -126,20 +113,9 @@ public class DispatcherTests
     {
         // Arrange
         var command = new TestCommand { Value = "" };
-        var validatorMock = new Mock<IValidator<ICommand<int>>>();
-        var validationResult = new ValidationResult(new[]
-        {
-            new ValidationFailure("Value", "Value is required")
-        });
-
-        validatorMock
-            .Setup(v => v.ValidateAsync(It.IsAny<ValidationContext<ICommand<int>>>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(validationResult);
-
-        // Setup validators collection
         _serviceProviderMock
-            .Setup(sp => sp.GetService(typeof(IEnumerable<IValidator<ICommand<int>>>)))
-            .Returns(new[] { validatorMock.Object });
+            .Setup(sp => sp.GetService(typeof(IEnumerable<IValidator<TestCommand>>)))
+            .Returns(new IValidator<TestCommand>[] { new TestCommandValidator() });
 
         var dispatcher = new BuildingBlocks.Application.Dispatcher.Dispatcher(
             _serviceProviderMock.Object,
@@ -147,9 +123,6 @@ public class DispatcherTests
 
         // Act & Assert
         await Assert.ThrowsAsync<ValidationException>(() => dispatcher.DispatchAsync(command));
-        validatorMock.Verify(
-            v => v.ValidateAsync(It.IsAny<ValidationContext<ICommand<int>>>(), It.IsAny<CancellationToken>()),
-            Times.Once);
     }
 
     [Fact]
@@ -164,8 +137,8 @@ public class DispatcherTests
 
         // No validators
         _serviceProviderMock
-            .Setup(sp => sp.GetService(typeof(IEnumerable<IValidator<IQuery<string>>>)))
-            .Returns(Enumerable.Empty<IValidator<IQuery<string>>>());
+            .Setup(sp => sp.GetService(typeof(IEnumerable<IValidator<TestQuery>>)))
+            .Returns(Enumerable.Empty<IValidator<TestQuery>>());
 
         var dispatcher = new BuildingBlocks.Application.Dispatcher.Dispatcher(
             _serviceProviderMock.Object,
@@ -183,8 +156,8 @@ public class DispatcherTests
 
         // No validators
         _serviceProviderMock
-            .Setup(sp => sp.GetService(typeof(IEnumerable<IValidator<ICommand<int>>>)))
-            .Returns(Enumerable.Empty<IValidator<ICommand<int>>>());
+            .Setup(sp => sp.GetService(typeof(IEnumerable<IValidator<TestCommand>>)))
+            .Returns(Enumerable.Empty<IValidator<TestCommand>>());
 
         // No handler
         _serviceProviderMock
@@ -274,6 +247,22 @@ public class DispatcherTests
     public record TestCommand : ICommand<int>
     {
         public string Value { get; init; } = string.Empty;
+    }
+
+    public sealed class TestQueryValidator : AbstractValidator<TestQuery>
+    {
+        public TestQueryValidator()
+        {
+            RuleFor(x => x.Value).NotEmpty().WithMessage("Value is required");
+        }
+    }
+
+    public sealed class TestCommandValidator : AbstractValidator<TestCommand>
+    {
+        public TestCommandValidator()
+        {
+            RuleFor(x => x.Value).NotEmpty().WithMessage("Value is required");
+        }
     }
 
     private static void ResetEventHandlers(params Type[] handlerTypes)


### PR DESCRIPTION
## Summary
This PR stabilizes the test baseline so the template can present a reliable quality signal.

### Changes
- fix dispatcher validation resolution to avoid hard failure when validator collections are not registered in DI
- update dispatcher unit tests to validate against concrete request validators
- add missing `Auditing.Infrastructure` project reference to integration test project

### Validation
- `dotnet test tests/CleanArchitecture.UnitTests/CleanArchitecture.UnitTests.csproj --no-restore` ✅ (34/34)
- `dotnet test tests/CleanArchitecture.IntegrationTests/CleanArchitecture.IntegrationTests.csproj --no-restore` ✅ (31/31)
- `dotnet test ModularMonolith.sln --no-restore` ✅

## Notes
This PR is scoped to test stability and CI confidence.