### PR TITLE
test(api): expand auditing integration coverage for auth and pagination

### DIFF
--- a/tests/CleanArchitecture.IntegrationTests/Controllers/AuditingIntegrationTests.cs
+++ b/tests/CleanArchitecture.IntegrationTests/Controllers/AuditingIntegrationTests.cs
@@ -37,4 +37,29 @@ public class AuditingIntegrationTests : IClassFixture<SqlServerWebApplicationFac
         content.Should().Contain("\"data\"");
         content.Should().Contain("POST /api/v1/categories");
     }
+
+    [Fact]
+    public async Task GetAuditEntries_WithoutAuthentication_ReturnsUnauthorized()
+    {
+        // Act
+        var response = await _client.GetAsync("/api/v1/auditlogs");
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task GetAuditEntries_WithPaginationQuery_ReturnsOk()
+    {
+        await AuthenticationTestHelper.AuthenticateAsync(_client);
+
+        // Act
+        var response = await _client.GetAsync("/api/v1/auditlogs?pageNumber=1&pageSize=5");
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var content = await response.Content.ReadAsStringAsync();
+        content.Should().Contain("\"success\"");
+        content.Should().Contain("\"data\"");
+    }
 }

--- a/tests/CleanArchitecture.IntegrationTests/Controllers/CatalogIntegrationTests.cs
+++ b/tests/CleanArchitecture.IntegrationTests/Controllers/CatalogIntegrationTests.cs
@@ -79,6 +79,17 @@ public class CatalogIntegrationTests : IClassFixture<SqlServerWebApplicationFact
     #region Category Tests
 
     [Fact]
+    public async Task CreateCategory_WithoutAuthentication_ReturnsUnauthorized()
+    {
+        var response = await _client.PostAsJsonAsync("/api/v1/categories", new
+        {
+            CategoryName = "Unauthorized Category"
+        });
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
     public async Task CreateCategory_WithValidData_ReturnsCreated()
     {
         await AuthenticationTestHelper.AuthenticateAsync(_client);
@@ -253,6 +264,18 @@ public class CatalogIntegrationTests : IClassFixture<SqlServerWebApplicationFact
     #endregion
 
     #region Product Tests
+
+    [Fact]
+    public async Task CreateProduct_WithoutAuthentication_ReturnsUnauthorized()
+    {
+        var response = await _client.PostAsJsonAsync("/api/v1/products", new
+        {
+            ProductName = "Unauthorized Product",
+            CategoryId = Guid.NewGuid().ToString()
+        });
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
 
     [Fact]
     public async Task CreateProduct_WithValidData_ReturnsCreated()

--- a/tests/CleanArchitecture.IntegrationTests/Controllers/IdentityIntegrationTests.cs
+++ b/tests/CleanArchitecture.IntegrationTests/Controllers/IdentityIntegrationTests.cs
@@ -369,6 +369,16 @@ public class IdentityIntegrationTests : IClassFixture<SqlServerWebApplicationFac
         response.StatusCode.Should().Be(HttpStatusCode.OK);
     }
 
+    [Fact]
+    public async Task Logout_WithoutAuthentication_ReturnsUnauthorized()
+    {
+        _client.DefaultRequestHeaders.Authorization = null;
+
+        var response = await _client.PostAsync("/api/v1/authentication/logout", content: null);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
     #endregion
 
     #region Email Confirmation Tests


### PR DESCRIPTION
## Summary
- add unauthorized access test for `GET /api/v1/auditlogs`
- add pagination query test for `GET /api/v1/auditlogs?pageNumber=1&pageSize=5`
- add unauthorized test for `POST /api/v1/authentication/logout`
- add unauthorized tests for protected catalog write endpoints:
  - `POST /api/v1/categories`
  - `POST /api/v1/products`

## Validation
- Integration tests pass after updates (`dotnet test tests/CleanArchitecture.IntegrationTests/CleanArchitecture.IntegrationTests.csproj --no-restore`)
