### PR TITLE
feat(api): standardize validation and exception error contract

### DIFF
--- a/src/CleanArchitecture.Api/Middleware/ExceptionHandlingMiddleware.cs
+++ b/src/CleanArchitecture.Api/Middleware/ExceptionHandlingMiddleware.cs
@@ -1,5 +1,5 @@
+using BuildingBlocks.Api.Responses;
 using FluentValidation;
-using Microsoft.AspNetCore.Mvc;
 using Serilog;
 
 namespace CleanArchitecture.Api.Middleware;
@@ -33,15 +33,7 @@ public class ExceptionHandlingMiddleware
     {
         context.Response.ContentType = "application/json";
 
-        var response = new ProblemDetails
-        {
-            Title = "An error occurred while processing your request.",
-            Status = context.Response.StatusCode,
-            Detail = exception.Message,
-            Instance = context.Request.Path
-        };
-
-        context.Response.StatusCode = exception switch
+        var statusCode = exception switch
         {
             ArgumentException => StatusCodes.Status400BadRequest,
             InvalidOperationException => StatusCodes.Status400BadRequest,
@@ -51,7 +43,13 @@ public class ExceptionHandlingMiddleware
             _ => StatusCodes.Status500InternalServerError
         };
 
-        response.Status = context.Response.StatusCode;
+        context.Response.StatusCode = statusCode;
+
+        var errorMessage = statusCode == StatusCodes.Status500InternalServerError
+            ? "An internal server error occurred"
+            : exception.Message;
+
+        var response = ApiResponse.CreateError(errorMessage, statusCode);
 
         return context.Response.WriteAsJsonAsync(response);
     }

--- a/src/CleanArchitecture.Api/Program.cs
+++ b/src/CleanArchitecture.Api/Program.cs
@@ -16,6 +16,7 @@ using Identity.Infrastructure.Persistence;
 using Auditing.Infrastructure.Persistence;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 using Microsoft.AspNetCore.HttpOverrides;
+using BuildingBlocks.Api.Responses;
 using Microsoft.AspNetCore.Mvc;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -46,6 +47,20 @@ builder.Services.AddScoped<IEntityChangeBuffer, EntityChangeBuffer>();
 builder.Services.AddScoped<IAuditOutboxProcessor, AuditOutboxProcessor>();
 builder.Services.AddHostedService<AuditOutboxWorker>();
 builder.Services.AddControllers();
+builder.Services.Configure<ApiBehaviorOptions>(options =>
+{
+    options.InvalidModelStateResponseFactory = context =>
+    {
+        var firstError = context.ModelState
+            .Where(x => x.Value?.Errors.Count > 0)
+            .SelectMany(x => x.Value!.Errors)
+            .Select(x => x.ErrorMessage)
+            .FirstOrDefault() ?? "Validation failed.";
+
+        var response = BuildingBlocks.Api.Responses.ApiResponse.CreateError(firstError, StatusCodes.Status400BadRequest);
+        return new BadRequestObjectResult(response);
+    };
+});
 builder.Services.AddSwaggerGen();
 builder.Services.AddAuthorization();
 builder.Services.AddHealthChecks()

--- a/tests/CleanArchitecture.IntegrationTests/Controllers/CatalogIntegrationTests.cs
+++ b/tests/CleanArchitecture.IntegrationTests/Controllers/CatalogIntegrationTests.cs
@@ -128,6 +128,10 @@ public class CatalogIntegrationTests : IClassFixture<SqlServerWebApplicationFact
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        var content = await response.Content.ReadAsStringAsync();
+        content.Should().Contain("\"success\":false");
+        content.Should().Contain("\"statusCode\":400");
+        content.Should().Contain("\"error\"");
     }
 
     [Fact]

--- a/tests/CleanArchitecture.IntegrationTests/Controllers/IdentityIntegrationTests.cs
+++ b/tests/CleanArchitecture.IntegrationTests/Controllers/IdentityIntegrationTests.cs
@@ -113,6 +113,10 @@ public class IdentityIntegrationTests : IClassFixture<SqlServerWebApplicationFac
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        var content = await response.Content.ReadAsStringAsync();
+        content.Should().Contain("\"success\":false");
+        content.Should().Contain("\"statusCode\":400");
+        content.Should().Contain("\"error\"");
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- standardize unhandled exception responses to `ApiResponse` error shape
- configure `ApiBehaviorOptions.InvalidModelStateResponseFactory` to return consistent 400 error contract for model validation failures
- add/strengthen integration assertions for error response shape in Identity + Catalog invalid request scenarios

## Validation
- Integration tests: 43/43 pass
- Unit tests: 36/36 pass