### PR TITLE
ci(quality): enforce build + unit + integration test gates

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -1,26 +1,37 @@
 name: ci-tests
 
 on:
-    push:
-        branches:
-            - main
-            - master
-    pull_request:
+  push:
+    branches:
+      - main
+      - master
+  pull_request:
+
+concurrency:
+  group: ci-tests-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
-    test:
-        runs-on: ubuntu-latest
-        steps:
-            - name: Checkout
-              uses: actions/checkout@v4
+  build-and-test:
+    runs-on: ubuntu-latest
 
-            - name: Setup .NET
-              uses: actions/setup-dotnet@v4
-              with:
-                  dotnet-version: "8.0.x"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
 
-            - name: Restore
-              run: dotnet restore
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "8.0.x"
 
-            - name: Test
-              run: dotnet test --configuration Release
+      - name: Restore
+        run: dotnet restore ModularMonolith.sln
+
+      - name: Build (Release)
+        run: dotnet build ModularMonolith.sln --configuration Release --no-restore
+
+      - name: Unit tests
+        run: dotnet test tests/CleanArchitecture.UnitTests/CleanArchitecture.UnitTests.csproj --configuration Release --no-build --verbosity minimal
+
+      - name: Integration tests
+        run: dotnet test tests/CleanArchitecture.IntegrationTests/CleanArchitecture.IntegrationTests.csproj --configuration Release --no-build --verbosity minimal


### PR DESCRIPTION
## Summary
- harden CI workflow with explicit restore/build/test stages
- run unit and integration tests separately for clearer failures
- keep no-restore/no-build optimization where appropriate
- add concurrency cancellation for duplicate runs

## Local verification
- build: pass
- unit tests: 36/36 pass
- integration tests: 43/43 pass