### PR TITLE
test(api): strengthen error contract assertions for identity and catalog

### DIFF
--- a/tests/CleanArchitecture.IntegrationTests/Controllers/CatalogIntegrationTests.cs
+++ b/tests/CleanArchitecture.IntegrationTests/Controllers/CatalogIntegrationTests.cs
@@ -74,6 +74,9 @@ public class CatalogIntegrationTests : IClassFixture<SqlServerWebApplicationFact
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        var content = await response.Content.ReadAsStringAsync();
+        content.Should().Contain("\"success\":false");
+        content.Should().Contain("\"error\"");
     }
 
     #region Category Tests

--- a/tests/CleanArchitecture.IntegrationTests/Controllers/IdentityIntegrationTests.cs
+++ b/tests/CleanArchitecture.IntegrationTests/Controllers/IdentityIntegrationTests.cs
@@ -542,3 +542,4 @@ public class IdentityIntegrationTests : IClassFixture<SqlServerWebApplicationFac
 
     #endregion
 }
+


### PR DESCRIPTION
## Summary
- add explicit error-envelope assertions for `GET /api/v1/products/{invalidId}` (404)
- keep unauthorized logout assertion status-based (empty body from challenge is expected)
- keep identity/catalog integration suite green after stricter checks

## Validation
- `dotnet test tests/CleanArchitecture.IntegrationTests/CleanArchitecture.IntegrationTests.csproj --no-restore --filter "FullyQualifiedName~IdentityIntegrationTests|FullyQualifiedName~CatalogIntegrationTests"` passes