### PR TITLE
test(security): verify security headers in gateway hardening integration tests

### DIFF
--- a/tests/CleanArchitecture.IntegrationTests/Controllers/GatewayHardeningIntegrationTests.cs
+++ b/tests/CleanArchitecture.IntegrationTests/Controllers/GatewayHardeningIntegrationTests.cs
@@ -31,6 +31,23 @@ public class GatewayHardeningIntegrationTests : IClassFixture<SqlServerWebApplic
     }
 
     [Fact]
+    public async Task SecurityHeaders_ArePresentOnResponses()
+    {
+        var response = await _client.GetAsync("/health/live");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Headers.TryGetValues("X-Content-Type-Options", out var contentTypeOptions).Should().BeTrue();
+        response.Headers.TryGetValues("X-Frame-Options", out var frameOptions).Should().BeTrue();
+        response.Headers.TryGetValues("Referrer-Policy", out var referrerPolicy).Should().BeTrue();
+        response.Headers.TryGetValues("Content-Security-Policy", out var csp).Should().BeTrue();
+
+        contentTypeOptions!.Single().Should().Be("nosniff");
+        frameOptions!.Single().Should().Be("DENY");
+        referrerPolicy!.Single().Should().Be("no-referrer");
+        csp!.Single().Should().Contain("default-src 'none'");
+    }
+
+    [Fact]
     public async Task LoginEndpoint_WhenFlooded_ReturnsTooManyRequests()
     {
         HttpResponseMessage? lastResponse = null;


### PR DESCRIPTION
## Summary
- add integration test to validate key security headers on API responses
- keep existing gateway hardening tests (health + rate-limit)

## Validation
- GatewayHardeningIntegrationTests: 3/3 pass
- Full integration suite: 44/44 pass