### PR TITLE
feat(health): include build version in health response

### DIFF
--- a/.github/workflows/api-ci-cd.yml
+++ b/.github/workflows/api-ci-cd.yml
@@ -168,6 +168,7 @@ jobs:
           DB_USER="${API_POSTGRES_USER:-postgres}"
           DB_PASSWORD="${API_POSTGRES_PASSWORD:-postgres}"
           CONNECTION_STRING="Host=postgres;Port=5432;Database=$DB_NAME;Username=$DB_USER;Password=$DB_PASSWORD"
+          BUILD_VERSION="${GITHUB_RUN_NUMBER}.${GITHUB_RUN_ATTEMPT}-${GITHUB_SHA::7}"
 
           if [ -n "$API_REGISTRY_USERNAME" ] && [ -n "$API_REGISTRY_TOKEN" ]; then
             ssh -p "$PORT" "$DEPLOY_USER@$DEPLOY_HOST" "echo '$API_REGISTRY_TOKEN' | docker login ghcr.io -u '$API_REGISTRY_USERNAME' --password-stdin"
@@ -190,6 +191,7 @@ jobs:
                 ApiSecurity__AllowCredentials: $ALLOW_CREDENTIALS
                 ApiSecurity__KnownProxies__0: $KNOWN_PROXIES
                 ConnectionStrings__DefaultConnection: $CONNECTION_STRING
+                APP_BUILD_VERSION: $BUILD_VERSION
             postgres:
               restart: always
               environment:

--- a/src/ModularMonolith/CleanArchitecture.Api/HealthChecks/HealthCheckResponseWriter.cs
+++ b/src/ModularMonolith/CleanArchitecture.Api/HealthChecks/HealthCheckResponseWriter.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using System.Text.Json;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 
@@ -5,6 +6,8 @@ namespace CleanArchitecture.Api.HealthChecks;
 
 public static class HealthCheckResponseWriter
 {
+    private static readonly string ApplicationVersion = ResolveApplicationVersion();
+
     public static Task WriteJsonAsync(HttpContext context, HealthReport report)
     {
         context.Response.ContentType = "application/json";
@@ -12,6 +15,7 @@ public static class HealthCheckResponseWriter
         var payload = new
         {
             status = report.Status.ToString(),
+            version = ApplicationVersion,
             totalDuration = report.TotalDuration.TotalMilliseconds,
             checks = report.Entries.Select(entry => new
             {
@@ -24,5 +28,19 @@ public static class HealthCheckResponseWriter
         };
 
         return context.Response.WriteAsync(JsonSerializer.Serialize(payload));
+    }
+
+    private static string ResolveApplicationVersion()
+    {
+        var runtimeVersion = Environment.GetEnvironmentVariable("APP_BUILD_VERSION");
+        if (!string.IsNullOrWhiteSpace(runtimeVersion))
+        {
+            return runtimeVersion;
+        }
+
+        var assembly = Assembly.GetExecutingAssembly();
+        return assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion
+               ?? assembly.GetName().Version?.ToString()
+               ?? "unknown";
     }
 }


### PR DESCRIPTION
## Summary\n- add ersion field to /health/live and /health/ready JSON payload\n- resolve version from APP_BUILD_VERSION env var, fallback to assembly informational version\n- stamp deployment runtime with CI build version (unNumber.runAttempt-sha7) in API deploy workflow\n\n## Why\nThis provides deterministic release traceability after each CI/CD run and makes it easy to verify what version is live from health endpoints.