### PR TITLE
fix(ci): stabilize integration auth setup with fake email config

### DIFF
--- a/tests/CleanArchitecture.IntegrationTests/Controllers/IdentityIntegrationTests.cs
+++ b/tests/CleanArchitecture.IntegrationTests/Controllers/IdentityIntegrationTests.cs
@@ -5,6 +5,7 @@ using System.Text.Json;
 using System.Text.RegularExpressions;
 using FluentAssertions;
 using CleanArchitecture.IntegrationTests.Infrastructure;
+using Identity.Application.Services;
 using Identity.Infrastructure.Services;
 using Microsoft.AspNetCore.WebUtilities;
 
@@ -49,7 +50,7 @@ public class IdentityIntegrationTests : IClassFixture<PostgresWebApplicationFact
 
     private static (string userId, string token) ExtractUserIdAndTokenFromLastEmail(string recipient)
     {
-        var message = FakeEmailService.GetLastMessage(recipient);
+        var message = WaitForLastMessage(recipient, timeoutMs: 3000, pollMs: 100);
         message.Should().NotBeNull("Expected an email to be sent");
 
         var link = ExtractFirstLink(message!.TextBody);
@@ -63,6 +64,23 @@ public class IdentityIntegrationTests : IClassFixture<PostgresWebApplicationFact
         token.Should().NotBeNullOrEmpty();
 
         return (userId, token);
+    }
+
+    private static EmailMessage? WaitForLastMessage(string recipient, int timeoutMs, int pollMs)
+    {
+        var start = DateTime.UtcNow;
+        while ((DateTime.UtcNow - start).TotalMilliseconds < timeoutMs)
+        {
+            var message = FakeEmailService.GetLastMessage(recipient);
+            if (message != null)
+            {
+                return message;
+            }
+
+            Thread.Sleep(pollMs);
+        }
+
+        return null;
     }
 
     private static string ExtractFirstLink(string text)

--- a/tests/CleanArchitecture.IntegrationTests/Infrastructure/AuthenticationTestHelper.cs
+++ b/tests/CleanArchitecture.IntegrationTests/Infrastructure/AuthenticationTestHelper.cs
@@ -3,6 +3,7 @@ using System.Net.Http.Json;
 using System.Text.Json;
 using System.Text.RegularExpressions;
 using FluentAssertions;
+using Identity.Application.Services;
 using Identity.Infrastructure.Services;
 using Microsoft.AspNetCore.WebUtilities;
 
@@ -69,7 +70,7 @@ internal static class AuthenticationTestHelper
 
     private static (string userId, string token) ExtractUserIdAndTokenFromLastEmail(string recipient)
     {
-        var message = FakeEmailService.GetLastMessage(recipient);
+        var message = WaitForLastMessage(recipient, timeoutMs: 3000, pollMs: 100);
         message.Should().NotBeNull("Expected an email to be sent");
 
         var link = ExtractFirstLink(message!.TextBody);
@@ -83,6 +84,23 @@ internal static class AuthenticationTestHelper
         token.Should().NotBeNullOrEmpty();
 
         return (userId, token);
+    }
+
+    private static EmailMessage? WaitForLastMessage(string recipient, int timeoutMs, int pollMs)
+    {
+        var start = DateTime.UtcNow;
+        while ((DateTime.UtcNow - start).TotalMilliseconds < timeoutMs)
+        {
+            var message = FakeEmailService.GetLastMessage(recipient);
+            if (message != null)
+            {
+                return message;
+            }
+
+            Thread.Sleep(pollMs);
+        }
+
+        return null;
     }
 
     private static string ExtractFirstLink(string text)

--- a/tests/CleanArchitecture.IntegrationTests/Infrastructure/PostgresWebApplicationFactory.cs
+++ b/tests/CleanArchitecture.IntegrationTests/Infrastructure/PostgresWebApplicationFactory.cs
@@ -34,21 +34,21 @@ public class PostgresWebApplicationFactory : WebApplicationFactory<Program>, IAs
 
     protected override void ConfigureWebHost(IWebHostBuilder builder)
     {
-        if (_useTestcontainers && TryEnsureContainer())
+        builder.ConfigureAppConfiguration((context, config) =>
         {
-            _connectionString = BuildConnectionString(_container!);
-
-            builder.ConfigureAppConfiguration((context, config) =>
+            var settings = new Dictionary<string, string?>
             {
-                var settings = new Dictionary<string, string?>
-                {
-                    ["ConnectionStrings:DefaultConnection"] = _connectionString,
-                    ["EmailSettings:UseFakeEmail"] = "true"
-                };
+                ["EmailSettings:UseFakeEmail"] = "true"
+            };
 
-                config.AddInMemoryCollection(settings);
-            });
-        }
+            if (_useTestcontainers && TryEnsureContainer())
+            {
+                _connectionString = BuildConnectionString(_container!);
+                settings["ConnectionStrings:DefaultConnection"] = _connectionString;
+            }
+
+            config.AddInMemoryCollection(settings);
+        });
 
         builder.ConfigureTestServices(services =>
         {


### PR DESCRIPTION
## Why\nAPI Quality Gates failed on develop in pi-integration-tests because some tests expected fake email tokens, but EmailSettings:UseFakeEmail was only injected when testcontainers mode was enabled.\n\n## What\n- always inject EmailSettings:UseFakeEmail=true in integration test host config\n- only inject testcontainer connection string conditionally\n\n## Verification\n- reran failing tests locally:\n  - IdentityIntegrationTests.RefreshToken_WithValidToken_ReturnsOkWithNewToken ✅\n  - CatalogIntegrationTests.CreateProduct_WithInvalidData_ReturnsBadRequest ✅